### PR TITLE
add `HOST_STATIC_SITE` env-flag with static hard-coded content

### DIFF
--- a/mlflow/server/js/config-overrides.js
+++ b/mlflow/server/js/config-overrides.js
@@ -41,6 +41,7 @@ function rewiredOverrides(config, env) {
   config = rewireDefinePlugin(config, env, {
     'process.env': {
       HIDE_HEADER: process.env.HIDE_HEADER ? JSON.stringify('true') : JSON.stringify('false'),
+      HOST_STATIC_SITE: process.env.HOST_STATIC_SITE === "true",
       HIDE_EXPERIMENT_LIST: process.env.HIDE_EXPERIMENT_LIST
         ? JSON.stringify('true')
         : JSON.stringify('false'),

--- a/mlflow/server/js/makefile
+++ b/mlflow/server/js/makefile
@@ -52,9 +52,13 @@ watch-ui:
 	# --- Not used (?) ---
 	# SHOULD_REDIRECT_IFRAME
 	#
+	# --- Static version of ML Flow ---
+	# HOST_STATIC_SITE
+	#    set to "true" for hosting static (read only) version of ML Flow
 	# -----------------------------
 	(\
 	    PORT=3001 \
+	    HOST_STATIC_SITE=true \
 	    npm start \
 	)
 

--- a/mlflow/server/js/makefile
+++ b/mlflow/server/js/makefile
@@ -1,11 +1,16 @@
 # The below commands can be run inside image build with ML Flow repo root Dockerfile
 
 start-backend:
-
+	# clear any old experiments/artefacts
 	rm -rf /repo-root/mlflow/mlruns
+
 	(\
 	    cd /repo-root/; \
+	    rm -rf /repo-root/backend; \
+		mkdir -p /repo-root/backend/artefacts; \
 	    mlflow server \
+	        --backend-store-uri sqlite:////repo-root/backend/sqlite.db \
+	        --default-artifact-root /repo-root/backend/artefacts/ \
 	        --host 0.0.0.0 \
 	        --port 5000 \
 	        --gunicorn-opts '--log-level debug' \
@@ -29,11 +34,13 @@ watch-ui:
 	# PORT
 	#
 	# --- Front end customization ---
-	# HIDE_HEADER=true/false
+	# HIDE_HEADER
 	#      Show top header with logo and Github link?
+	#      Note, header hidden if flag is defined. Eg.,
+	#      "HIDE_HEADER=false" will hide header.
 	#
 	# HIDE_EXPERIMENT_LIST
-	#      Seems unstable. Setting to True leads to "No Experiments Exist"
+	#      Seems unstable? Setting leads to "No Experiments Exist"
 	#
 	# SHOW_GDPR_PURGING_MESSAGES
 	#      Display comment when deleting experiments
@@ -48,7 +55,6 @@ watch-ui:
 	# -----------------------------
 	(\
 	    PORT=3001 \
-	    HIDE_HEADER=false \
 	    npm start \
 	)
 
@@ -58,3 +64,7 @@ watch-ui:
 	# VS Code if running a dev-container setup.
 	#apt install -y lsof
 	#kill -9 $(lsof -i:3001 -t)
+
+start-sqlite-web-ui:
+	pip3 install sqlite-web==0.4.0
+	sqlite_web --port 5012 /repo-root/backend/sqlite.db

--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -171,8 +171,6 @@ export const searchRunsPayload = ({
   };
 
   return getApiData("searchRuns", args).then((res) => (shouldFetchParents ? fetchMissingParents(res) : res));
-
-  return wrapDeferred(MlflowService.searchRuns, args).then((res) => (shouldFetchParents ? fetchMissingParents(res) : res));
 };
 
 export const SEARCH_RUNS_API = 'SEARCH_RUNS_API';

--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -12,6 +12,7 @@ export const getApiData = (methodName, arg) => {
   );
 };
 
+// ****** Supported also for static data UI ******
 export const LIST_EXPERIMENTS_API = 'LIST_EXPERIMENTS_API';
 export const listExperimentsApi = (id = getUUID()) => {
   return {
@@ -21,6 +22,7 @@ export const listExperimentsApi = (id = getUUID()) => {
   };
 };
 
+// ****** Supported also for static data UI ******
 export const GET_EXPERIMENT_API = 'GET_EXPERIMENT_API';
 export const getExperimentApi = (experimentId, id = getUUID()) => {
   return {
@@ -72,11 +74,12 @@ export const updateExperimentApi = (experimentId, newExperimentName, id = getUUI
   };
 };
 
+// ****** Supported also for static data UI ******
 export const GET_RUN_API = 'GET_RUN_API';
 export const getRunApi = (runId, id = getUUID()) => {
   return {
     type: GET_RUN_API,
-    payload: wrapDeferred(MlflowService.getRun, { run_id: runId }),
+    payload: getApiData("getRun", { run_id: runId }),
     meta: { id: id },
   };
 };
@@ -157,15 +160,19 @@ export const searchRunsPayload = ({
   orderBy,
   pageToken,
   shouldFetchParents,
-}) =>
-  wrapDeferred(MlflowService.searchRuns, {
+}) => {
+  const args = {
     experiment_ids: experimentIds,
     filter: filter,
     run_view_type: runViewType,
     max_results: maxResults || SEARCH_MAX_RESULTS,
     order_by: orderBy,
     page_token: pageToken,
-  }).then((res) => (shouldFetchParents ? fetchMissingParents(res) : res));
+  };
+
+
+  return wrapDeferred(MlflowService.searchRuns, args).then((res) => (shouldFetchParents ? fetchMissingParents(res) : res));
+};
 
 export const SEARCH_RUNS_API = 'SEARCH_RUNS_API';
 export const searchRunsApi = (params) => ({
@@ -181,12 +188,14 @@ export const loadMoreRunsApi = (params) => ({
   meta: { id: params.id || getUUID() },
 });
 
+// ****** Supported also for static data UI ******
 // TODO: run_uuid is deprecated, use run_id instead
 export const LIST_ARTIFACTS_API = 'LIST_ARTIFACTS_API';
 export const listArtifactsApi = (runUuid, path, id = getUUID()) => {
   return {
     type: LIST_ARTIFACTS_API,
-    payload: wrapDeferred(MlflowService.listArtifacts, {
+    payload:
+    getApiData("listArtifacts", {
       run_uuid: runUuid,
       path: path,
     }),

--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -1,14 +1,22 @@
 import { MlflowService } from './sdk/MlflowService';
+import { StaticMlflowService } from './static-data/StaticMlflowService';
 import { getUUID, wrapDeferred } from '../common/utils/ActionUtils';
 import { ErrorCodes } from '../common/constants';
 
 export const SEARCH_MAX_RESULTS = 100;
 
+export const getApiData = (methodName, arg) => {
+  return (process.env.HOST_STATIC_SITE
+    ? StaticMlflowService[methodName](arg)
+    : wrapDeferred(MlflowService[methodName], arg)
+  );
+};
+
 export const LIST_EXPERIMENTS_API = 'LIST_EXPERIMENTS_API';
 export const listExperimentsApi = (id = getUUID()) => {
   return {
     type: LIST_EXPERIMENTS_API,
-    payload: wrapDeferred(MlflowService.listExperiments, {}),
+    payload: getApiData("listExperiments", {}),
     meta: { id: id },
   };
 };
@@ -17,7 +25,7 @@ export const GET_EXPERIMENT_API = 'GET_EXPERIMENT_API';
 export const getExperimentApi = (experimentId, id = getUUID()) => {
   return {
     type: GET_EXPERIMENT_API,
-    payload: wrapDeferred(MlflowService.getExperiment, { experiment_id: experimentId }),
+    payload: getApiData("getExperiment", { experiment_id: experimentId }),
     meta: { id: id },
   };
 };

--- a/mlflow/server/js/src/experiment-tracking/actions.js
+++ b/mlflow/server/js/src/experiment-tracking/actions.js
@@ -170,6 +170,7 @@ export const searchRunsPayload = ({
     page_token: pageToken,
   };
 
+  return getApiData("searchRuns", args).then((res) => (shouldFetchParents ? fetchMissingParents(res) : res));
 
   return wrapDeferred(MlflowService.searchRuns, args).then((res) => (shouldFetchParents ? fetchMissingParents(res) : res));
 };

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticData.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticData.js
@@ -1,0 +1,123 @@
+export const STATIC_EXPERIMENTS = {
+    experiments: [{
+            experiment_id: '0',
+            name: 'Experiment #0',
+            artifact_location: './mlruns/0',
+            lifecycle_stage: 'active',
+            tags: [{
+                key: 'mlflow.note.content',
+                value: 'Description shown when opening experiment page. #0',
+            }, ],
+        },
+        {
+            experiment_id: '1',
+            name: 'My experiment #1',
+            artifact_location: './mlruns/1',
+            lifecycle_stage: 'active',
+            tags: [{
+                key: 'mlflow.note.content',
+                value: 'Description shown when opening experiment page. #1',
+            }, ],
+        },
+        {
+            experiment_id: '2',
+            name: 'Last experiment #2',
+            artifact_location: './mlruns/2',
+            lifecycle_stage: 'active',
+        },
+    ]
+};
+
+export const STATIC_RUNS = [{
+        info: {
+            run_uuid: "00000000000000000000000000000000",
+            experiment_id: "0",
+            user_id: "root",
+            status: "FINISHED",
+            start_time: 1645952322527,
+            end_time: 1645952322545,
+            artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000000/artifacts",
+            lifecycle_stage: "active",
+            run_id: "00000000000000000000000000000000"
+        },
+        data: {
+            tags: [{
+                    key: "mlflow.user",
+                    value: "root"
+                },
+                {
+                    key: "mlflow.source.name",
+                    value: "/path/to/my/main-file.py"
+                },
+                {
+                    key: "mlflow.source.type",
+                    value: "LOCAL"
+                },
+                {
+                    key: "mlflow.source.git.commit",
+                    value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                {
+                    key: "mlflow.runName",
+                    value: "my-run-name"
+                },
+                {
+                    key: "foo",
+                    value: "bar"
+                },
+                {
+                    key: "mlflow.note.content",
+                    value: "this is a run description"
+                }
+            ]
+        }
+    },
+    {
+        info: {
+            run_uuid: "00000000000000000000000000000111",
+            experiment_id: "0",
+            user_id: "root",
+            status: "FINISHED",
+            start_time: 1645952322527,
+            end_time: 1645952322545,
+            artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000111/artifacts",
+            lifecycle_stage: "active",
+            run_id: "00000000000000000000000000000111"
+        },
+        data: {
+            tags: [{
+                    key: "mlflow.user",
+                    value: "root"
+                },
+                {
+                    key: "mlflow.source.name",
+                    value: "/path/to/my/source-file.py"
+                },
+                {
+                    key: "mlflow.source.type",
+                    value: "LOCAL"
+                },
+                {
+                    key: "mlflow.source.git.commit",
+                    value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                {
+                    key: "mlflow.parentRunId",
+                    value: "00000000000000000000000000000000"
+                },
+                {
+                    key: "mlflow.runName",
+                    value: "my-run-name"
+                },
+                {
+                    key: "foo",
+                    value: "bar"
+                },
+                {
+                    key: "mlflow.note.content",
+                    value: "this is a run description"
+                }
+            ]
+        }
+    }
+];

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -8,7 +8,7 @@ const one = (xs) => {
   if (xs.length === 1) {
     return xs[0];
   } else {
-    throw new Error('Expected one result; found ${xs.length}')
+    throw new Error("Expected one result; found ${xs.length}");
   }
 };
 

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -29,101 +29,99 @@ const LIST_EXPERIMENTS_API_STATIC_RESPONSE = {
 };
 
 
-const ALL_RUNS = {
-  runs: [{
-      info: {
-        run_uuid: "00000000000000000000000000000000",
-        experiment_id: "0",
-        user_id: "root",
-        status: "FINISHED",
-        start_time: 1645952322527,
-        end_time: 1645952322545,
-        artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000000/artifacts",
-        lifecycle_stage: "active",
-        run_id: "00000000000000000000000000000000"
-      },
-      data: {
-        tags: [{
-            key: "mlflow.user",
-            value: "root"
-          },
-          {
-            key: "mlflow.source.name",
-            value: "/path/to/my/main-file.py"
-          },
-          {
-            key: "mlflow.source.type",
-            value: "LOCAL"
-          },
-          {
-            key: "mlflow.source.git.commit",
-            value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-          },
-          {
-            key: "mlflow.runName",
-            value: "my-run-name"
-          },
-          {
-            key: "foo",
-            value: "bar"
-          },
-          {
-            key: "mlflow.note.content",
-            value: "this is a run description"
-          }
-        ]
-      }
+const ALL_RUNS = [{
+    info: {
+      run_uuid: "00000000000000000000000000000000",
+      experiment_id: "0",
+      user_id: "root",
+      status: "FINISHED",
+      start_time: 1645952322527,
+      end_time: 1645952322545,
+      artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000000/artifacts",
+      lifecycle_stage: "active",
+      run_id: "00000000000000000000000000000000"
     },
-    {
-      info: {
-        run_uuid: "00000000000000000000000000000111",
-        experiment_id: "0",
-        user_id: "root",
-        status: "FINISHED",
-        start_time: 1645952322527,
-        end_time: 1645952322545,
-        artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000111/artifacts",
-        lifecycle_stage: "active",
-        run_id: "00000000000000000000000000000111"
-      },
-      data: {
-        tags: [{
-            key: "mlflow.user",
-            value: "root"
-          },
-          {
-            key: "mlflow.source.name",
-            value: "/path/to/my/source-file.py"
-          },
-          {
-            key: "mlflow.source.type",
-            value: "LOCAL"
-          },
-          {
-            key: "mlflow.source.git.commit",
-            value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-          },
-          {
-            key: "mlflow.parentRunId",
-            value: "00000000000000000000000000000000"
-          },
-          {
-            key: "mlflow.runName",
-            value: "my-run-name"
-          },
-          {
-            key: "foo",
-            value: "bar"
-          },
-          {
-            key: "mlflow.note.content",
-            value: "this is a run description"
-          }
-        ]
-      }
+    data: {
+      tags: [{
+          key: "mlflow.user",
+          value: "root"
+        },
+        {
+          key: "mlflow.source.name",
+          value: "/path/to/my/main-file.py"
+        },
+        {
+          key: "mlflow.source.type",
+          value: "LOCAL"
+        },
+        {
+          key: "mlflow.source.git.commit",
+          value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          key: "mlflow.runName",
+          value: "my-run-name"
+        },
+        {
+          key: "foo",
+          value: "bar"
+        },
+        {
+          key: "mlflow.note.content",
+          value: "this is a run description"
+        }
+      ]
     }
-  ]
-};
+  },
+  {
+    info: {
+      run_uuid: "00000000000000000000000000000111",
+      experiment_id: "0",
+      user_id: "root",
+      status: "FINISHED",
+      start_time: 1645952322527,
+      end_time: 1645952322545,
+      artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000111/artifacts",
+      lifecycle_stage: "active",
+      run_id: "00000000000000000000000000000111"
+    },
+    data: {
+      tags: [{
+          key: "mlflow.user",
+          value: "root"
+        },
+        {
+          key: "mlflow.source.name",
+          value: "/path/to/my/source-file.py"
+        },
+        {
+          key: "mlflow.source.type",
+          value: "LOCAL"
+        },
+        {
+          key: "mlflow.source.git.commit",
+          value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+        },
+        {
+          key: "mlflow.parentRunId",
+          value: "00000000000000000000000000000000"
+        },
+        {
+          key: "mlflow.runName",
+          value: "my-run-name"
+        },
+        {
+          key: "foo",
+          value: "bar"
+        },
+        {
+          key: "mlflow.note.content",
+          value: "this is a run description"
+        }
+      ]
+    }
+  }
+];
 
 const one = (xs) => {
   if (xs.length === 1) {
@@ -141,7 +139,7 @@ export class StaticMlflowService {
   static getExperiment({
     experiment_id
   }) {
-    return new Promise((resolve, error) => {
+    return new Promise((resolve, reject) => {
       resolve(
         LIST_EXPERIMENTS_API_STATIC_RESPONSE
         .experiments
@@ -154,10 +152,9 @@ export class StaticMlflowService {
   static getRun({
     run_id
   }) {
-    return new Promise((resolve, error) => {
+    return new Promise((resolve, reject) => {
       resolve(
-        ALL_RUNS.runs
-        .filter((entry) => entry.info.run_id === run_id))
+        ALL_RUNS.filter((entry) => entry.info.run_id === run_id))
     }).then(xs => ({
       run: one(xs)
     }))
@@ -167,6 +164,27 @@ export class StaticMlflowService {
     run_uuid,
     path
   }) {
-    return new Promise((resolve, error) => resolve([]));
+    return new Promise((resolve, reject) => resolve([]));
+  }
+
+  static searchRuns({
+    experiment_ids,
+    filter, // ignore for now (TODO?); eg. "", undefined
+    run_view_type, // ignore, can be "ACTIVE_ONLY" or undefined
+    max_results, // ignore
+    order_by, // ignore for now (TODO); eg.  ["attributes.start_time DESC"]
+    page_token, // assumed always NULL (max_results not respected)
+  }) {
+    if (!!page_token) {
+      return new Promise((resolve, reject) => reject(new Error("Load more not supported in static mode.")));
+    }
+
+    const filteredRuns = ALL_RUNS.filter(runEntry => experiment_ids.includes(runEntry.info.experiment_id));
+
+    return new Promise((resolve, reject) => {
+      resolve({
+        runs: filteredRuns
+      });
+    });
   }
 }

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -1,0 +1,56 @@
+const LIST_EXPERIMENTS_API_STATIC_RESPONSE = {
+    experiments: [
+      {
+        experiment_id: '0',
+        name: 'Experiment #0',
+        artifact_location: './mlruns/0',
+        lifecycle_stage: 'active',
+        tags: [
+          {
+            key: 'mlflow.note.content',
+            value: 'Description shown when opening experiment page. #0',
+          },
+        ],
+      },
+      {
+        experiment_id: '1',
+        name: 'My experiment #1',
+        artifact_location: './mlruns/1',
+        lifecycle_stage: 'active',
+        tags: [
+          {
+            key: 'mlflow.note.content',
+            value: 'Description shown when opening experiment page. #1',
+          },
+        ],
+      },
+      {
+        experiment_id: '2',
+        name: 'runs-but-no-metrics-params',
+        artifact_location: './mlruns/2',
+        lifecycle_stage: 'active',
+      },
+    ],
+  };
+
+export class StaticMlflowService {
+  static listExperiments(_) {
+    return new Promise((resolve, reject) => resolve(LIST_EXPERIMENTS_API_STATIC_RESPONSE));
+  };
+
+  static getExperiment({ experiment_id }) {
+    return new Promise((resolve, error) => {
+      const results = (
+        LIST_EXPERIMENTS_API_STATIC_RESPONSE
+          .experiments
+          .filter((entry) => entry.experiment_id === experiment_id)
+        );
+
+      if (results.length === 1) {
+        resolve({experiment: results[0]});
+      } else {
+        error(new Error('No (unique) data found for experiment {experimentId}'));
+      }
+    });
+  }
+}

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -1,56 +1,172 @@
 const LIST_EXPERIMENTS_API_STATIC_RESPONSE = {
-    experiments: [
-      {
-        experiment_id: '0',
-        name: 'Experiment #0',
-        artifact_location: './mlruns/0',
-        lifecycle_stage: 'active',
-        tags: [
-          {
-            key: 'mlflow.note.content',
-            value: 'Description shown when opening experiment page. #0',
+  experiments: [{
+      experiment_id: '0',
+      name: 'Experiment #0',
+      artifact_location: './mlruns/0',
+      lifecycle_stage: 'active',
+      tags: [{
+        key: 'mlflow.note.content',
+        value: 'Description shown when opening experiment page. #0',
+      }, ],
+    },
+    {
+      experiment_id: '1',
+      name: 'My experiment #1',
+      artifact_location: './mlruns/1',
+      lifecycle_stage: 'active',
+      tags: [{
+        key: 'mlflow.note.content',
+        value: 'Description shown when opening experiment page. #1',
+      }, ],
+    },
+    {
+      experiment_id: '2',
+      name: 'Last experiment #2',
+      artifact_location: './mlruns/2',
+      lifecycle_stage: 'active',
+    },
+  ]
+};
+
+
+const ALL_RUNS = {
+  runs: [{
+      info: {
+        run_uuid: "00000000000000000000000000000000",
+        experiment_id: "0",
+        user_id: "root",
+        status: "FINISHED",
+        start_time: 1645952322527,
+        end_time: 1645952322545,
+        artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000000/artifacts",
+        lifecycle_stage: "active",
+        run_id: "00000000000000000000000000000000"
+      },
+      data: {
+        tags: [{
+            key: "mlflow.user",
+            value: "root"
           },
-        ],
-      },
-      {
-        experiment_id: '1',
-        name: 'My experiment #1',
-        artifact_location: './mlruns/1',
-        lifecycle_stage: 'active',
-        tags: [
           {
-            key: 'mlflow.note.content',
-            value: 'Description shown when opening experiment page. #1',
+            key: "mlflow.source.name",
+            value: "/path/to/my/main-file.py"
           },
-        ],
+          {
+            key: "mlflow.source.type",
+            value: "LOCAL"
+          },
+          {
+            key: "mlflow.source.git.commit",
+            value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          {
+            key: "mlflow.runName",
+            value: "my-run-name"
+          },
+          {
+            key: "foo",
+            value: "bar"
+          },
+          {
+            key: "mlflow.note.content",
+            value: "this is a run description"
+          }
+        ]
+      }
+    },
+    {
+      info: {
+        run_uuid: "00000000000000000000000000000111",
+        experiment_id: "0",
+        user_id: "root",
+        status: "FINISHED",
+        start_time: 1645952322527,
+        end_time: 1645952322545,
+        artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000111/artifacts",
+        lifecycle_stage: "active",
+        run_id: "00000000000000000000000000000111"
       },
-      {
-        experiment_id: '2',
-        name: 'runs-but-no-metrics-params',
-        artifact_location: './mlruns/2',
-        lifecycle_stage: 'active',
-      },
-    ],
-  };
+      data: {
+        tags: [{
+            key: "mlflow.user",
+            value: "root"
+          },
+          {
+            key: "mlflow.source.name",
+            value: "/path/to/my/source-file.py"
+          },
+          {
+            key: "mlflow.source.type",
+            value: "LOCAL"
+          },
+          {
+            key: "mlflow.source.git.commit",
+            value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+          },
+          {
+            key: "mlflow.parentRunId",
+            value: "00000000000000000000000000000000"
+          },
+          {
+            key: "mlflow.runName",
+            value: "my-run-name"
+          },
+          {
+            key: "foo",
+            value: "bar"
+          },
+          {
+            key: "mlflow.note.content",
+            value: "this is a run description"
+          }
+        ]
+      }
+    }
+  ]
+};
+
+const one = (xs) => {
+  if (xs.length === 1) {
+    return xs[0];
+  } else {
+    throw new Error('Expected one result; found ${xs.length}')
+  }
+};
 
 export class StaticMlflowService {
-  static listExperiments(_) {
+  static listExperiments(dummy_arg) {
     return new Promise((resolve, reject) => resolve(LIST_EXPERIMENTS_API_STATIC_RESPONSE));
   };
 
-  static getExperiment({ experiment_id }) {
+  static getExperiment({
+    experiment_id
+  }) {
     return new Promise((resolve, error) => {
-      const results = (
+      resolve(
         LIST_EXPERIMENTS_API_STATIC_RESPONSE
-          .experiments
-          .filter((entry) => entry.experiment_id === experiment_id)
-        );
+        .experiments
+        .filter((entry) => entry.experiment_id === experiment_id))
+    }).then(xs => ({
+      experiment: one(xs)
+    }))
+  }
 
-      if (results.length === 1) {
-        resolve({experiment: results[0]});
-      } else {
-        error(new Error('No (unique) data found for experiment {experimentId}'));
-      }
-    });
+  static getRun({
+    run_id
+  }) {
+    return new Promise((resolve, error) => {
+      resolve(
+        ALL_RUNS.runs
+        .filter((entry) => entry.info.run_id === run_id))
+    }).then(xs => ({
+      run: one(xs)
+    }))
+  }
+
+  static listArtifacts({
+    run_uuid,
+    path
+  }) {
+    return new Promise((resolve, error) => resolve([]));
   }
 }

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -1,127 +1,8 @@
-const LIST_EXPERIMENTS_API_STATIC_RESPONSE = {
-  experiments: [{
-      experiment_id: '0',
-      name: 'Experiment #0',
-      artifact_location: './mlruns/0',
-      lifecycle_stage: 'active',
-      tags: [{
-        key: 'mlflow.note.content',
-        value: 'Description shown when opening experiment page. #0',
-      }, ],
-    },
-    {
-      experiment_id: '1',
-      name: 'My experiment #1',
-      artifact_location: './mlruns/1',
-      lifecycle_stage: 'active',
-      tags: [{
-        key: 'mlflow.note.content',
-        value: 'Description shown when opening experiment page. #1',
-      }, ],
-    },
-    {
-      experiment_id: '2',
-      name: 'Last experiment #2',
-      artifact_location: './mlruns/2',
-      lifecycle_stage: 'active',
-    },
-  ]
-};
+import {
+  STATIC_EXPERIMENTS,
+  STATIC_RUNS
+} from './StaticData';
 
-
-const ALL_RUNS = [{
-    info: {
-      run_uuid: "00000000000000000000000000000000",
-      experiment_id: "0",
-      user_id: "root",
-      status: "FINISHED",
-      start_time: 1645952322527,
-      end_time: 1645952322545,
-      artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000000/artifacts",
-      lifecycle_stage: "active",
-      run_id: "00000000000000000000000000000000"
-    },
-    data: {
-      tags: [{
-          key: "mlflow.user",
-          value: "root"
-        },
-        {
-          key: "mlflow.source.name",
-          value: "/path/to/my/main-file.py"
-        },
-        {
-          key: "mlflow.source.type",
-          value: "LOCAL"
-        },
-        {
-          key: "mlflow.source.git.commit",
-          value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          key: "mlflow.runName",
-          value: "my-run-name"
-        },
-        {
-          key: "foo",
-          value: "bar"
-        },
-        {
-          key: "mlflow.note.content",
-          value: "this is a run description"
-        }
-      ]
-    }
-  },
-  {
-    info: {
-      run_uuid: "00000000000000000000000000000111",
-      experiment_id: "0",
-      user_id: "root",
-      status: "FINISHED",
-      start_time: 1645952322527,
-      end_time: 1645952322545,
-      artifact_uri: "/repo-root/backend/artefacts/0/00000000000000000000000000000111/artifacts",
-      lifecycle_stage: "active",
-      run_id: "00000000000000000000000000000111"
-    },
-    data: {
-      tags: [{
-          key: "mlflow.user",
-          value: "root"
-        },
-        {
-          key: "mlflow.source.name",
-          value: "/path/to/my/source-file.py"
-        },
-        {
-          key: "mlflow.source.type",
-          value: "LOCAL"
-        },
-        {
-          key: "mlflow.source.git.commit",
-          value: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-        },
-        {
-          key: "mlflow.parentRunId",
-          value: "00000000000000000000000000000000"
-        },
-        {
-          key: "mlflow.runName",
-          value: "my-run-name"
-        },
-        {
-          key: "foo",
-          value: "bar"
-        },
-        {
-          key: "mlflow.note.content",
-          value: "this is a run description"
-        }
-      ]
-    }
-  }
-];
 
 const one = (xs) => {
   if (xs.length === 1) {
@@ -133,7 +14,7 @@ const one = (xs) => {
 
 export class StaticMlflowService {
   static listExperiments(dummy_arg) {
-    return new Promise((resolve, reject) => resolve(LIST_EXPERIMENTS_API_STATIC_RESPONSE));
+    return new Promise((resolve, reject) => resolve(STATIC_EXPERIMENTS));
   };
 
   static getExperiment({
@@ -141,7 +22,7 @@ export class StaticMlflowService {
   }) {
     return new Promise((resolve, reject) => {
       resolve(
-        LIST_EXPERIMENTS_API_STATIC_RESPONSE
+        STATIC_EXPERIMENTS
         .experiments
         .filter((entry) => entry.experiment_id === experiment_id))
     }).then(xs => ({
@@ -154,7 +35,7 @@ export class StaticMlflowService {
   }) {
     return new Promise((resolve, reject) => {
       resolve(
-        ALL_RUNS.filter((entry) => entry.info.run_id === run_id))
+        STATIC_RUNS.filter((entry) => entry.info.run_id === run_id))
     }).then(xs => ({
       run: one(xs)
     }))
@@ -164,6 +45,7 @@ export class StaticMlflowService {
     run_uuid,
     path
   }) {
+    // TOOO: implement ARTEFACT_LIST_PER_STATIC_RUN etc with static hosted content
     return new Promise((resolve, reject) => resolve([]));
   }
 
@@ -179,7 +61,7 @@ export class StaticMlflowService {
       return new Promise((resolve, reject) => reject(new Error("Load more not supported in static mode.")));
     }
 
-    const filteredRuns = ALL_RUNS.filter(runEntry => experiment_ids.includes(runEntry.info.experiment_id));
+    const filteredRuns = STATIC_RUNS.filter(runEntry => experiment_ids.includes(runEntry.info.experiment_id));
 
     return new Promise((resolve, reject) => {
       resolve({

--- a/mlflow/server/js/src/model-registry/actions.js
+++ b/mlflow/server/js/src/model-registry/actions.js
@@ -157,9 +157,15 @@ export const searchModelVersionsApi = (filterObj, id = getUUID()) => {
     })
     .join('&');
 
+  // always return no models in static setting
+  const queryResult = (process.env.HOST_STATIC_SITE
+    ? new Promise((resolve, reject) => resolve(({})))
+    : wrapDeferred(Services.searchModelVersions, { filter })
+  );
+
   return {
     type: SEARCH_MODEL_VERSIONS,
-    payload: wrapDeferred(Services.searchModelVersions, { filter }),
+    payload: queryResult,
     meta: { id },
   };
 };


### PR DESCRIPTION
Add support for environment variable `HOST_STATIC_SITE` to React front end. 

When `HOST_STATIC_SITE=true`, the UI serves static data provided in the file `StaticData.js`. Then there is no need for tracking backend, and the UI is read-only.

This PR adds support for statically hosted:
- experiments, 
- runs (inc. nested runs)

Not supported
- run artifacts
- models
- filtering runs, search order

----

This PR contains captured data from the ML Flow backend API (eg., this is how the content in the `StaticData.js` file was created). It is assumed that this content is not copyrightable. With this assumption, the code/modifications in this PR are copyright Matias Dahl 2022 and released under the terms of the Apache 2 license.