### PR TITLE
Add attachments to UI

### DIFF
--- a/mlflow/server/js/makefile
+++ b/mlflow/server/js/makefile
@@ -58,7 +58,7 @@ watch-ui:
 	#    set to "true" for hosting static (read only) version of ML Flow
 	# -----------------------------
 	(\
-	    PORT=3001 \
+	    PORT=3010 \
 	    HOST_STATIC_SITE=true \
 	    npm start \
 	)
@@ -108,10 +108,10 @@ docker-serve-static-ui-in-watch-mode:
 	#
 	# the below will install npm packages in mounted directory first time run
 	#
-	# Static website served in watch mode on localhost:3001
+	# Static website served in watch mode on localhost:3010
 	docker run -it --rm \
 	    --volume $$(pwd):/mlflow-server-js \
-		--publish 3001:3001 \
+	    --publish 3010:3010 \
 	    ui_build_image \
 	    bash -c "( \
 	        cd /mlflow-server-js/; \

--- a/mlflow/server/js/makefile
+++ b/mlflow/server/js/makefile
@@ -2,23 +2,23 @@
 # --- repo root Dockerfile + VS Code dev container setup
 
 start-backend:
-	# clear any old experiments/artefacts
+	# clear any old experiments/artifacts
 	rm -rf /repo-root/mlflow/mlruns
 
 	(\
 	    cd /repo-root/; \
 	    rm -rf /repo-root/backend; \
-		mkdir -p /repo-root/backend/artefacts; \
+		mkdir -p /repo-root/backend/artifacts; \
 	    mlflow server \
 	        --backend-store-uri sqlite:////repo-root/backend/sqlite.db \
-	        --default-artifact-root /repo-root/backend/artefacts/ \
+	        --default-artifact-root /repo-root/backend/artifacts/ \
 	        --host 0.0.0.0 \
 	        --port 5000 \
 	        --gunicorn-opts '--log-level debug' \
 	)
 
 populate-backend:
-	# Populate backend with test experiment data (but no artefacts)
+	# Populate backend with test experiment data (but no artifacts)
 	(\
 	    MLFLOW_TRACKING_URI=http://127.0.0.1:5000 \
 	    python3 /repo-root/tests/generate_ui_test_data.py \

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactPage.js
@@ -15,6 +15,7 @@ import Utils from '../../common/utils/Utils';
 import { getUUID } from '../../common/utils/ActionUtils';
 import './ArtifactPage.css';
 import { getLoggedModelPathsFromTags } from '../../common/utils/TagUtils';
+import { STATIC_DATA }  from '../static-data/StaticData';
 
 export class ArtifactPageImpl extends Component {
   static propTypes = {
@@ -161,6 +162,26 @@ const mapStateToProps = (state, ownProps) => {
       selectedPath = _.first(loggedModelPaths);
     }
   }
+
+  if (process.env.HOST_STATIC_SITE) {
+    const containsArtifact = (filename) => (
+      STATIC_DATA[runUuid]
+        .artifacts
+        .filter((k) => k.name == filename)
+        .length == 1
+    );
+
+    // (for notebook tasks) show rendered notebook if it exists
+    if (!selectedPath && containsArtifact("notebook.html")) {
+      selectedPath = "notebook.html";
+    }
+
+    // (for pipelines) show json summary if it exists
+    if (!selectedPath && containsArtifact("pipeline.json")) {
+      selectedPath = "pipeline.json";
+    }
+  }
+
   return { artifactRootUri, apis, initialSelectedArtifactPath: selectedPath };
 };
 

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
@@ -193,7 +193,8 @@ export class ArtifactViewImpl extends Component {
     if (artifactNode.fileInfo) {
       const { path } = artifactNode.fileInfo;
       id = path;
-      name = getBasename(path);
+      // list artifacts: automatically expand all directories for static website
+      name = process.env.HOST_STATIC_SITE ? artifactNode.fileInfo.path : getBasename(path);
     }
 
     const toggleState = this.state.toggledNodeIds[id];

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
@@ -92,7 +92,7 @@ export class ArtifactViewImpl extends Component {
               description='Label to display the full path of where the artifact of the experiment runs is located'
             />
           </label>{' '}
-          <Text className='artifact-info-text' ellipsis copyable>
+          <Text className='artifact-info-text' copyable>
             {activeNodeRealPath}
           </Text>
         </div>

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -119,6 +119,10 @@ export class RunViewImpl extends Component {
   getRunCommand() {
     const { tags, params } = this.props;
     let runCommand = null;
+    if (process.env.HOST_STATIC_SITE) {
+      return runCommand;
+    }
+
     const sourceName = Utils.getSourceName(tags);
     const sourceVersion = Utils.getSourceVersion(tags);
     const entryPointName = Utils.getEntryPointName(tags);

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
@@ -1,3 +1,4 @@
+import { STATIC_DATA } from '../../static-data/StaticData';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -140,8 +141,12 @@ const getFileTooLargeView = () => {
 };
 
 export const getSrc = (path, runUuid) => {
-  const basePath = 'get-artifact';
-  return `${basePath}?path=${encodeURIComponent(path)}&run_uuid=${encodeURIComponent(runUuid)}`;
+  if (process.env.HOST_STATIC_SITE) {
+    return `pipeline-artifacts/${STATIC_DATA[runUuid].artifacts_location}/${path}`;
+  } else {
+    const basePath = 'get-artifact';
+    return `${basePath}?path=${encodeURIComponent(path)}&run_uuid=${encodeURIComponent(runUuid)}`;
+  }
 };
 
 export default ShowArtifactPage;

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -149,8 +149,8 @@ const reformatEntry = (runId, entry, experimentId) => {
               }
             };
             return [
-              ...addImage("DAG diagram of task dependencies", "dag-diagram.png"),
-              ...addImage("Gantt diagram of task runs", "gantt-diagram.png")
+              ...addImage("DAG diagram of task dependencies in pipeline", "dag-diagram.png"),
+              ...addImage("Gantt diagram of task runs in pipeline", "gantt-diagram.png")
             ].join("\n");
           } else {
             return "No description";
@@ -247,8 +247,26 @@ export class StaticMlflowService {
     run_uuid,
     path
   }) {
-    // TOOO: implement ARTEFACT_LIST_PER_STATIC_RUN etc with static hosted content
-    return new Promise((resolve, reject) => resolve([]));
+    const entry = STATIC_DATA[run_uuid];
+    var result;
+
+    if (!!entry && !!entry.artifacts) {
+      // return all files with directories expanded
+      result = {
+        "root_uri": "/path/to/somewhere/",
+        "files": [...entry.artifacts.map((entry) => ({
+          path: entry.name,
+          is_dir: false,
+          file_size: entry.size
+        }))]
+      };
+    } else {
+      result = {
+        root_uri: null,
+        files: []
+      };
+    }
+    return new Promise((resolve, reject) => resolve(result));
   }
 
   static searchRuns({

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -137,19 +137,19 @@ const reformatEntry = (runId, entry, experimentId) => {
           // -- determine description --
           if (isPipeline && !!entry.artifacts) {
             const addImage = (header, filename) => {
-              const artifact_entries = entry.artifacts.filter((k) => k.file_name == filename);
+              const artifact_entries = entry.artifacts.filter((k) => k.name == filename);
 
               if (artifact_entries.length === 1) {
                 return [
                   `# ${header}`,
-                  `![${header}](./pipeline-artifacts/${one(artifact_entries).artifact_path})`
+                  `![${header}](./pipeline-artifacts/${entry.artifacts_location}/${filename})`
                 ];
               } else {
                 return [];
               }
             };
             return [
-              ...addImage("DAG diagram of task dependencies in pipeline", "dag-diagram.png"),
+              ...addImage("DAG diagram of task dependencies in this pipeline", "dag-diagram.png"),
               ...addImage("Gantt diagram of task runs in pipeline", "gantt-diagram.png")
             ].join("\n");
           } else {

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -135,9 +135,52 @@ const reformatEntry = (runId, entry, experimentId) => {
         key: "mlflow.note.content",
         value: "description missing"
       }
-      ]
+      ],
+      params: [...Object.entries(entry.metadata.attributes)
+        .map(([k, v]) => ({key: k, value: v}))
+      ],
+      metrics: []
     }
   };
+
+  // --- add logged metrics ---
+  // The complexity of the below code is due to our Python interface
+  // allows logging of arbitrary dicts/arrays, but MLFlow only allow
+  // numeric metrics.
+  //
+  // Also, this only keeps track of *one value* for the metric; ie.
+  // this does not support logging a loss function during training.
+  if (!!entry.metadata.logged_values) {
+    const log_kv = (k, v) => {
+      if (Number(v) !== v) {
+        throw new Error(`Too complex logged value ${k}=${v}`);
+      }
+
+      result.data.metrics.push({
+        key: k,
+        value: JSON.stringify(v),
+        // -- only one value --
+        timestamp: entry.metadata.start_time,
+        step: 0
+      });
+    };
+
+    Object.entries(entry.metadata.logged_values).forEach(([k, v]) => {
+      if ((v.type === "int") || (v.type === "float")) {
+        log_kv(k, v.value);
+      } else if ((v.type === "json") && Array.isArray(v.value)) {
+        for (const [idx, x] of v.value.entries()) {
+          log_kv(k + "." + idx, x);
+        }
+      } else if (v.type === "json") {
+        for (const [idx, x] of Object.entries(v.value)) {
+          log_kv(k + "=" + idx, x);
+        }
+      } else {
+        throw new Error(`Too complex logged value ${k}=${v}`);
+      }
+    });
+  }
 
   if (entry.type === "run") {
     const parentTaskId = STATIC_DATA[runId].parent_id;

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -85,7 +85,7 @@ const reformatEntry = (runId, entry, experimentId) => {
   if (isPipeline) {
     sourceName = "Pipeline run";
   } else {
-    sourceName = entry["metadata"]["attributes"]["task.notebook"];
+    sourceName = entry["metadata"]["attributes"]["task.notebook"] || "Unknown"
   }
 
   const isSucess = (entry.metadata.status && entry.metadata.status.status_code && (entry.metadata.status.status_code == "OK"));
@@ -116,7 +116,7 @@ const reformatEntry = (runId, entry, experimentId) => {
       },
       {
         key: "mlflow.source.type",
-        value: "LOCAL"
+        value: isPipeline ? "PROJECT" : "NOTEBOOK"
       },
       {
         key: "mlflow.source.git.commit",
@@ -142,7 +142,7 @@ const reformatEntry = (runId, entry, experimentId) => {
               if (artifact_entries.length === 1) {
                 return [
                   `# ${header}`,
-                  `![${header}](./pipeline-artefacts/${one(artifact_entries).artifact_path})`
+                  `![${header}](./pipeline-artifacts/${one(artifact_entries).artifact_path})`
                 ];
               } else {
                 return [];

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -137,7 +137,7 @@ const reformatEntry = (runId, entry, experimentId) => {
       }
       ],
       params: [...Object.entries(entry.metadata.attributes)
-        .map(([k, v]) => ({key: k, value: v}))
+        .map(([k, v]) => ({ key: k, value: v }))
       ],
       metrics: []
     }
@@ -158,7 +158,7 @@ const reformatEntry = (runId, entry, experimentId) => {
 
       result.data.metrics.push({
         key: k,
-        value: JSON.stringify(v),
+        value: v,
         // -- only one value --
         timestamp: entry.metadata.start_time,
         step: 0

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -85,7 +85,7 @@ const reformatEntry = (runId, entry, experimentId) => {
   if (isPipeline) {
     sourceName = "Pipeline run";
   } else {
-    sourceName = entry["metadata"]["attributes"]["task.notebook"] || "Unknown"
+    sourceName = entry["metadata"]["attributes"]["task.notebook"] || "Unknown";
   }
 
   const isSucess = (entry.metadata.status && entry.metadata.status.status_code && (entry.metadata.status.status_code == "OK"));

--- a/mlflow/server/js/src/experiment-tracking/utils/ArtifactUtils.js
+++ b/mlflow/server/js/src/experiment-tracking/utils/ArtifactUtils.js
@@ -26,9 +26,10 @@ export class ArtifactNode {
       this.children = {};
       this.isLoaded = true;
       fileInfos.forEach((fileInfo) => {
-        // basename is the last part of the path for this fileInfo.
+        // basename is the last part of the path for this fileInfo (except when
+        // HOST_STATIC_SITE=true; then all paths are expanded). See also, below.
         const pathParts = fileInfo.path.split('/');
-        const basename = pathParts[pathParts.length - 1];
+        const basename = process.env.HOST_STATIC_SITE ? fileInfo.path : pathParts[pathParts.length - 1];
         let children;
         if (fileInfo.is_dir) {
           children = [];
@@ -41,6 +42,9 @@ export class ArtifactNode {
   }
 
   static findChild(node, path) {
+    if (process.env.HOST_STATIC_SITE) {
+      return node.children[path];
+    }
     const parts = path.split('/');
     let ret = node;
     parts.forEach((part) => {

--- a/tests/generate_ui_test_data.py
+++ b/tests/generate_ui_test_data.py
@@ -51,6 +51,10 @@ if __name__ == "__main__":
             log_params(parameters)
             log_metrics(metrics)
 
+            mlflow.log_text("hello", "root_file.txt")
+            mlflow.log_text("world", "dir/data.txt")
+            mlflow.log_text("123", "dir/subdir/file.txt")
+
     # Runs with multiple values for a single metric so that we can QA the time-series metric
     # plot
     for i in range(3):


### PR DESCRIPTION
- include logged artifacts in mlflow run page
- default behavior for artifacts is to have files and directories as separate objects, and open directories when they are clicked: in static setup, all files are shown without any directory logic
- by default open `notebook.html` (for task runs) or `pipeline.json` (for pipeline runs)
- modified `tests/generate_ui_test_data.py` to create some test artifacts for testing the non-static setup. Eg what does the API messages look like?

---
The code/modifications in this PR copyright Matias Dahl 2022. Released under the terms of the Apache 2 license.