### PR TITLE
UI updates: remove edit features

### DIFF
--- a/mlflow/server/js/src/common/components/EditableTagsTableView.js
+++ b/mlflow/server/js/src/common/components/EditableTagsTableView.js
@@ -85,53 +85,55 @@ export class EditableTagsTableViewImpl extends Component {
           onSaveEdit={handleSaveEdit}
           onDelete={handleDeleteTag}
         />
-        <div style={styles.addTagForm.wrapper}>
-          <Form ref={innerRef} layout='inline' onFinish={handleAddTag}>
-            <Form.Item
-              name='name'
-              rules={[
-                {
-                  required: true,
-                  message: this.props.intl.formatMessage({
-                    defaultMessage: 'Name is required.',
+        {process.env.HOST_STATIC_SITE ? null :
+          (<div style={styles.addTagForm.wrapper}>
+            <Form ref={innerRef} layout='inline' onFinish={handleAddTag}>
+              <Form.Item
+                name='name'
+                rules={[
+                  {
+                    required: true,
+                    message: this.props.intl.formatMessage({
+                      defaultMessage: 'Name is required.',
+                      description:
+                        'Error message for name requirement in editable tags table view in MLflow',
+                    }),
+                    validator: this.tagNameValidator,
+                  },
+                ]}
+              >
+                <Input
+                  aria-label='tag name'
+                  placeholder={this.props.intl.formatMessage({
+                    defaultMessage: 'Name',
                     description:
-                      'Error message for name requirement in editable tags table view in MLflow',
-                  }),
-                  validator: this.tagNameValidator,
-                },
-              ]}
-            >
-              <Input
-                aria-label='tag name'
-                placeholder={this.props.intl.formatMessage({
-                  defaultMessage: 'Name',
-                  description:
-                    'Default text for name placeholder in editable tags table form in MLflow',
-                })}
-                style={styles.addTagForm.nameInput}
-              />
-            </Form.Item>
-            <Form.Item name='value' rules={[]}>
-              <Input
-                aria-label='tag value'
-                placeholder={this.props.intl.formatMessage({
-                  defaultMessage: 'Value',
-                  description:
-                    'Default text for value placeholder in editable tags table form in MLflow',
-                })}
-                style={styles.addTagForm.valueInput}
-              />
-            </Form.Item>
-            <Form.Item>
-              <Button loading={isRequestPending} htmlType='submit' data-test-id='add-tag-button'>
-                <FormattedMessage
-                  defaultMessage='Add'
-                  description='Add button text in editable tags table view in MLflow'
+                      'Default text for name placeholder in editable tags table form in MLflow',
+                  })}
+                  style={styles.addTagForm.nameInput}
                 />
-              </Button>
-            </Form.Item>
-          </Form>
-        </div>
+              </Form.Item>
+              <Form.Item name='value' rules={[]}>
+                <Input
+                  aria-label='tag value'
+                  placeholder={this.props.intl.formatMessage({
+                    defaultMessage: 'Value',
+                    description:
+                      'Default text for value placeholder in editable tags table form in MLflow',
+                  })}
+                  style={styles.addTagForm.valueInput}
+                />
+              </Form.Item>
+              <Form.Item>
+                <Button loading={isRequestPending} htmlType='submit' data-test-id='add-tag-button'>
+                  <FormattedMessage
+                    defaultMessage='Add'
+                    description='Add button text in editable tags table view in MLflow'
+                  />
+                </Button>
+              </Form.Item>
+            </Form>
+          </div>)
+        }
       </Spacer>
     );
   }

--- a/mlflow/server/js/src/common/components/tables/EditableFormTable.js
+++ b/mlflow/server/js/src/common/components/tables/EditableFormTable.js
@@ -72,7 +72,10 @@ export class EditableTable extends React.Component {
   // see ML-11973
   getTotalTableWidth = () => _.sumBy(this.columns, 'width');
 
-  initColumns = () => [
+
+
+  initColumns = () => {
+    const keyValueColumns = [
     ...this.props.columns.map((col) =>
       col.editable
         ? {
@@ -91,8 +94,9 @@ export class EditableTable extends React.Component {
             ),
           }
         : col,
-    ),
-    {
+    )];
+
+    const actionColumn = {
       title: (
         <FormattedMessage
           defaultMessage='Actions'
@@ -159,8 +163,10 @@ export class EditableTable extends React.Component {
           </span>
         );
       },
-    },
-  ];
+    };
+    // hide the edit/delete action column for static sites
+    return keyValueColumns.concat(process.env.HOST_STATIC_SITE ? [] : [actionColumn]);
+  };
 
   isEditing = (record) => record.key === this.state.editingKey;
 

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.js
@@ -130,13 +130,15 @@ export class ExperimentListView extends Component {
         />
         <div>
           <h1 className='experiments-header'>Experiments</h1>
-          <div className='experiment-list-create-btn-container'>
-            <i
-              onClick={this.handleCreateExperiment}
-              title='New Experiment'
-              className='fas fa-plus fa-border experiment-list-create-btn'
-            />
-          </div>
+          {process.env.HOST_STATIC_SITE ? null :
+            <div className='experiment-list-create-btn-container'>
+              <i
+                onClick={this.handleCreateExperiment}
+                title='New Experiment'
+                className='fas fa-plus fa-border experiment-list-create-btn'
+              />
+            </div>
+          }
           <div className='collapser-container'>
             <i
               onClick={this.props.onClickListExperiments}
@@ -144,14 +146,16 @@ export class ExperimentListView extends Component {
               className='collapser fa fa-chevron-left login-icon'
             />
           </div>
-          <Input
-            className='experiment-list-search-input'
-            type='text'
-            placeholder='Search Experiments'
-            aria-label='search experiments'
-            value={searchInput}
-            onChange={this.handleSearchInputChange}
-          />
+          {process.env.HOST_STATIC_SITE ? null :
+            <Input
+              className='experiment-list-search-input'
+              type='text'
+              placeholder='Search Experiments'
+              aria-label='search experiments'
+              value={searchInput}
+              onChange={this.handleSearchInputChange}
+            />
+          }
           <div className='experiment-list-container' style={{ height: experimentListHeight }}>
             {this.props.experiments
               // filter experiments based on searchInput
@@ -177,23 +181,27 @@ export class ExperimentListView extends Component {
                       to={Routes.getExperimentPageRoute(experiment_id)}
                       onClick={active ? (ev) => ev.preventDefault() : (ev) => ev}
                     >
-                      <div style={{ overflow: 'hidden', textOverflow: 'ellipsis' }}>{name}</div>
+                      <div style={{ overflow: 'hidden' }}>{name}</div>
                     </Link>
                     {/* Edit/Rename Experiment Option */}
-                    <IconButton
-                      icon={<EditOutlined />}
-                      onClick={this.handleRenameExperiment}
-                      data-experimentid={experiment_id}
-                      data-experimentname={name}
-                      style={{ marginRight: 10 }}
-                    />
+                    {process.env.HOST_STATIC_SITE ? null :
+                      <IconButton
+                        icon={<EditOutlined />}
+                        onClick={this.handleRenameExperiment}
+                        data-experimentid={experiment_id}
+                        data-experimentname={name}
+                        style={{ marginRight: 10 }}
+                      />
+                    }
                     {/* Delete Experiment option */}
-                    <IconButton
-                      icon={<i className='far fa-trash-alt' />}
-                      onClick={this.handleDeleteExperiment}
-                      data-experimentid={experiment_id}
-                      data-experimentname={name}
-                    />
+                    {process.env.HOST_STATIC_SITE ? null :
+                      <IconButton
+                        icon={<i className='far fa-trash-alt' />}
+                        onClick={this.handleDeleteExperiment}
+                        data-experimentid={experiment_id}
+                        data-experimentname={name}
+                      />
+                    }
                   </div>
                 );
               })}

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentView.js
@@ -99,7 +99,8 @@ export class ExperimentView extends Component {
       showNotesEditor: false,
       showNotes: true,
       showFilters: false,
-      showOnboardingHelper: onboardingInformationStore.getItem('showTrackingHelper') === null,
+      showOnboardingHelper: !process.env.HOST_STATIC_SITE &&
+        (onboardingInformationStore.getItem('showTrackingHelper') === null),
       searchInput: props.searchInput,
       lastExperimentId: undefined,
     };

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentViewHelpers.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentViewHelpers.js
@@ -26,7 +26,7 @@ export function ExperimentNoteSection(props) {
             defaultMessage='Description'
             description='Header for displaying notes for the experiment table'
           />
-          {!showNotesEditor && (
+          {!process.env.HOST_STATIC_SITE && !showNotesEditor && (
             <Button type='link' onClick={startEditingDescription}>
               <FormattedMessage
                 defaultMessage='Edit'

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -388,7 +388,7 @@ export class RunViewImpl extends Component {
                   defaultMessage='Description'
                   description='Label for the notes editable content for the experiment run'
                 />
-                {!showNoteEditor && (
+                {!process.env.HOST_STATIC_SITE && !showNoteEditor && (
                   <>
                     {' '}
                     <Button


### PR DESCRIPTION
From UI remove most edit and onboarding dialogs. In particular:
- remove: edit/delete/new tags
- remove: experiment search/delete/edit experiment name

---

The contributions in this PR are copyright Matias Dahl 2022 and released under the terms of the Apache 2 license.