### PR TITLE
Improved rendering of notebook artifacts

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.css
@@ -1,8 +1,8 @@
 div.artifact-view {
-  height: 690px;
   border: solid 1px #ccc;
   display: flex;
   overflow-x: scroll;
+  background: #fafafa;
 }
 
 .artifact-left {
@@ -19,6 +19,8 @@ div.artifact-view {
   flex: 3;
   min-width: 400px;
   max-width: calc(100% - 200px); /* 200px is the min-width of .artifact-left */
+  /* ideally, this view could expand to height of notebook iframe, now it is fixed */
+  height: 130vh;
 }
 
 .artifact-info {

--- a/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/ArtifactView.js
@@ -432,7 +432,6 @@ const TREEBEARD_STYLE = {
       backgroundColor: '#FAFAFA',
       fontSize: '14px',
       maxWidth: '500px',
-      height: '673px',
       overflow: 'scroll',
     },
     node: {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactHtmlView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactHtmlView.css
@@ -1,3 +1,6 @@
-.html-iframe {
+.artifact-html-iframe {
   border: none;
+
+  /* 56px is total height of artifact details above artifact (w. name and size) */
+  height: calc(100% - 56px);
 }

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactHtmlView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactHtmlView.js
@@ -54,9 +54,8 @@ class ShowArtifactHtmlView extends Component {
           url=''
           src={this.getBlobURL(this.state.html, 'text/html')}
           width='100%'
-          height='500px'
           id='html'
-          className='html-iframe'
+          className='artifact-html-iframe'
           display='block'
           position='relative'
           sandbox='allow-scripts'


### PR DESCRIPTION
Ideally notebook artifacts would be shown without scrollbar.

This PR makes the view-area for artifacts higher (although not full height for long notebooks).


----
The new contributions to the mlflow codebase in this PR are copyright Matias Dahl 2022, and are released under the terms of the Apache 2 license.
