### PR TITLE
Remove non-API access STATIC_DATA (pass `artifactRootUri` into artifact views)

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactHtmlView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactHtmlView.js
@@ -14,6 +14,7 @@ class ShowArtifactHtmlView extends Component {
   static propTypes = {
     runUuid: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
+    artifactRootUri: PropTypes.string.isRequired,
     getArtifact: PropTypes.func,
   };
 
@@ -71,7 +72,7 @@ class ShowArtifactHtmlView extends Component {
 
   /** Fetches artifacts and updates component state with the result */
   fetchArtifacts() {
-    const artifactLocation = getSrc(this.props.path, this.props.runUuid);
+    const artifactLocation = getSrc(this.props.path, this.props.runUuid, this.props.artifactRootUri);
     this.props
       .getArtifact(artifactLocation)
       .then((html) => {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactImageView.js
@@ -19,6 +19,7 @@ class ShowArtifactImageView extends Component {
   static propTypes = {
     runUuid: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
+    artifactRootUri: PropTypes.string.isRequired,
   };
 
   componentDidMount = () => {
@@ -42,8 +43,8 @@ class ShowArtifactImageView extends Component {
   };
 
   getSrc = () => {
-    const { path, runUuid } = this.props;
-    return getSrc(path, runUuid);
+    const { path, runUuid, artifactRootUri} = this.props;
+    return getSrc(path, runUuid, artifactRootUri);
   };
 
   isGif = () => {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.js
@@ -1,4 +1,3 @@
-import { STATIC_DATA } from '../../static-data/StaticData';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -58,19 +57,46 @@ class ShowArtifactPage extends Component {
         return getFileTooLargeView();
       } else if (normalizedExtension) {
         if (IMAGE_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
-          return <ShowArtifactImageView runUuid={this.props.runUuid} path={this.props.path} />;
+          return (
+            <ShowArtifactImageView
+              runUuid={this.props.runUuid}
+              path={this.props.path}
+              artifactRootUri={this.props.artifactRootUri}
+            />
+          );
         } else if (TEXT_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
-          return <ShowArtifactTextView runUuid={this.props.runUuid} path={this.props.path} />;
+          return (
+            <ShowArtifactTextView
+              runUuid={this.props.runUuid}
+              path={this.props.path}
+              artifactRootUri={this.props.artifactRootUri}
+            />
+          );
         } else if (MAP_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
+          if (process.env.HOST_STATIC_SITE) {
+            throw new Error("map-artifacts not supported in static mode");
+          }
           return <ShowArtifactMapView runUuid={this.props.runUuid} path={this.props.path} />;
         } else if (HTML_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
-          return <ShowArtifactHtmlView runUuid={this.props.runUuid} path={this.props.path} />;
+          return (
+            <ShowArtifactHtmlView
+              runUuid={this.props.runUuid}
+              path={this.props.path}
+              artifactRootUri={this.props.artifactRootUri}
+            />
+          );
         } else if (PDF_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
+          if (process.env.HOST_STATIC_SITE) {
+            throw new Error("pdf-artifacts not supported in static mode");
+          }
           return <ShowArtifactPdfView runUuid={this.props.runUuid} path={this.props.path} />;
         } else if (
           this.props.runTags &&
           getLoggedModelPathsFromTags(this.props.runTags).includes(normalizedExtension)
         ) {
+          if (process.env.HOST_STATIC_SITE) {
+            throw new Error("model-artifacts not supported in static mode");
+          }
           return (
             <ShowArtifactLoggedModelView
               runUuid={this.props.runUuid}
@@ -140,9 +166,9 @@ const getFileTooLargeView = () => {
   );
 };
 
-export const getSrc = (path, runUuid) => {
+export const getSrc = (path, runUuid, artifactRootUri) => {
   if (process.env.HOST_STATIC_SITE) {
-    return `pipeline-artifacts/${STATIC_DATA[runUuid].artifacts_location}/${path}`;
+    return `pipeline-artifacts/${artifactRootUri}/${path}`;
   } else {
     const basePath = 'get-artifact';
     return `${basePath}?path=${encodeURIComponent(path)}&run_uuid=${encodeURIComponent(runUuid)}`;

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.js
@@ -16,6 +16,7 @@ class ShowArtifactTextView extends Component {
   static propTypes = {
     runUuid: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
+    artifactRootUri: PropTypes.string.isRequired,
     getArtifact: PropTypes.func,
   };
 
@@ -82,7 +83,11 @@ class ShowArtifactTextView extends Component {
 
   /** Fetches artifacts and updates component state with the result */
   fetchArtifacts() {
-    const artifactLocation = getSrc(this.props.path, this.props.runUuid);
+    const artifactLocation = getSrc(
+      this.props.path,
+      this.props.runUuid,
+      this.props.artifactRootUri,
+    );
     this.props
       .getArtifact(artifactLocation)
       .then((text) => {

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -119,7 +119,7 @@ const reformatEntry = (runId, entry, experimentId) => {
       status: (isPipeline || isSucess) ? "FINISHED" : "FAILED",
       start_time: entry.metadata.start_time,
       end_time: entry.metadata.end_time,
-      artifact_uri: "artifact_uri",
+      artifact_uri: entry.artifacts_location,
       lifecycle_stage: "active",
       run_id: runId
     },


### PR DESCRIPTION
Do not access STATIC_DATA to determine url-path for fetching an artifact.

Rather pass `artifactRootUri` into artifact views. 

By having all access to STATIC_DATA done via API:s we can load the data dynamically

---

The contributions to the mlflow codebase in this PR are copyright Matias Dahl 2022, and are released under the terms of the Apache 2 license.