### PR TITLE
Load static data dynamically

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/App.js
+++ b/mlflow/server/js/src/experiment-tracking/components/App.js
@@ -25,6 +25,8 @@ import { ModelPage } from '../../model-registry/components/ModelPage';
 import { CompareModelVersionsPage } from '../../model-registry/components/CompareModelVersionsPage';
 import { SiteHeader } from '../static-data/UIConstants';
 
+import { StaticDataLoader } from '../static-data/StaticMlflowService';
+
 const isExperimentsActive = (match, location) => {
   // eslint-disable-next-line prefer-const
   let isActive = match && !location.pathname.includes('models');
@@ -36,8 +38,26 @@ const classNames = {
 };
 
 class App extends Component {
+
+  constructor(props) {
+    super(props);
+
+    console.log("StaticDataLoader", StaticDataLoader.state)
+
+    this.state = {
+      staticDataLoaderState: StaticDataLoader.state
+    };
+
+    StaticDataLoader.loaderPromise.then((value) => {
+      console.log("***** receivedData ******")
+      this.setState({
+        staticDataLoaderState: StaticDataLoader.state
+      });
+    })
+  }
+
   render() {
-    return (
+    const uiAfterDataHasLoaded = (
       <Router>
         <div style={{ height: '100vh' }}>
           <ErrorModal />
@@ -130,6 +150,14 @@ class App extends Component {
         </div>
       </Router>
     );
+
+    const state = this.state.staticDataLoaderState
+
+    if (state === "LOADED") {
+      return uiAfterDataHasLoaded;
+    } else {
+      return (<span> Data loading.... Please wait</span>);
+    }
   }
 }
 

--- a/mlflow/server/js/src/experiment-tracking/components/App.js
+++ b/mlflow/server/js/src/experiment-tracking/components/App.js
@@ -38,27 +38,27 @@ const classNames = {
 };
 
 class App extends Component {
-
   constructor(props) {
     super(props);
-
-    console.log("StaticDataLoader", StaticDataLoader.state)
 
     this.state = {
       staticDataLoaderState: StaticDataLoader.state
     };
 
     StaticDataLoader.loaderPromise.then((value) => {
-      console.log("***** receivedData ******")
       this.setState({
         staticDataLoaderState: StaticDataLoader.state
       });
-    })
+    });
   }
 
   render() {
-    const uiAfterDataHasLoaded = (
-      <Router>
+    const state = this.state.staticDataLoaderState
+
+    if (state === "LOADING") {
+      return (<span> Data loading.... Please wait</span>);
+    } else if (state === "LOADED") {
+      return (<Router>
         <div style={{ height: '100vh' }}>
           <ErrorModal />
           {process.env.HIDE_HEADER === 'true' ? null : (
@@ -148,15 +148,11 @@ class App extends Component {
             </Switch>
           </AppErrorBoundary>
         </div>
-      </Router>
-    );
-
-    const state = this.state.staticDataLoaderState
-
-    if (state === "LOADED") {
-      return uiAfterDataHasLoaded;
+      </Router>);
+    } else if (state === "FAILED") {
+      return (<span>Failed to load data</span>);
     } else {
-      return (<span> Data loading.... Please wait</span>);
+      throw new Error("Unknown state while loading static data");
     }
   }
 }

--- a/mlflow/server/js/src/experiment-tracking/components/App.js
+++ b/mlflow/server/js/src/experiment-tracking/components/App.js
@@ -45,11 +45,13 @@ class App extends Component {
       staticDataLoaderState: StaticDataLoader.state
     };
 
-    StaticDataLoader.loaderPromise.then((value) => {
+    const stateChangeHandler = () => {
       this.setState({
         staticDataLoaderState: StaticDataLoader.state
       });
-    });
+    };
+
+    StaticDataLoader.loaderPromise.then(stateChangeHandler);
   }
 
   render() {
@@ -156,6 +158,8 @@ class App extends Component {
         </div>
       </Router>);
     } else if (state === "FAILED") {
+      // todo: this will not currently render even when there are errors
+      // with static asset loading.
       return (<span>Failed to load data</span>);
     } else {
       throw new Error("Unknown state while loading static data");

--- a/mlflow/server/js/src/experiment-tracking/components/App.js
+++ b/mlflow/server/js/src/experiment-tracking/components/App.js
@@ -56,7 +56,13 @@ class App extends Component {
     const state = this.state.staticDataLoaderState
 
     if (state === "LOADING") {
-      return (<span> Data loading.... Please wait</span>);
+      return (
+        <div>
+          <span>
+            Data loading.... Please wait
+          </span>
+        </div>
+      );
     } else if (state === "LOADED") {
       return (<Router>
         <div style={{ height: '100vh' }}>

--- a/mlflow/server/js/src/experiment-tracking/components/App.js
+++ b/mlflow/server/js/src/experiment-tracking/components/App.js
@@ -51,7 +51,7 @@ class App extends Component {
       });
     };
 
-    StaticDataLoader.loaderPromise.then(stateChangeHandler);
+    StaticDataLoader.loaderPromise.then(stateChangeHandler).catch(stateChangeHandler);
   }
 
   render() {
@@ -158,8 +158,8 @@ class App extends Component {
         </div>
       </Router>);
     } else if (state === "FAILED") {
-      // todo: this will not currently render even when there are errors
-      // with static asset loading.
+      // Manually test by changing static asset to eg
+      // "http://foobar.test/this-url-does-not-exist"
       return (<span>Failed to load data</span>);
     } else {
       throw new Error("Unknown state while loading static data");

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticData.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticData.js
@@ -1,5 +1,0 @@
-// For local testing, STATIC_DATA can be copied from demo pipeline repo:
-//
-// https://github.com/pynb-dag-runner/mnist-digits-demo-pipeline
-//
-export const STATIC_DATA = {}

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -146,10 +146,10 @@ const reformatEntry = (runId, entry, experimentId) => {
   }
 
   if (entry.type === "run") {
-    const parentTaskId = StaticDataLoader.LOADED_STATIC_DATA[runId].parent_id;
+    const parentTaskId = StaticDataLoader.DATA[runId].parent_id;
     result.data.tags.push({
       key: "mlflow.parentRunId",
-      value: StaticDataLoader.LOADED_STATIC_DATA[parentTaskId].parent_id
+      value: StaticDataLoader.DATA[parentTaskId].parent_id
     });
   }
 
@@ -158,7 +158,7 @@ const reformatEntry = (runId, entry, experimentId) => {
 
 class StaticDataLoaderClass {
   // -- static data to show in UI --
-  LOADED_STATIC_DATA;
+  DATA;
   ALL_PIPELINE_RUN_IDS;
   PIPELINE_ID_TO_CHILDREN_RUN_IDS;
   LOOKUP_IDX_TO_TASK_SOURCE_NAME;
@@ -197,9 +197,9 @@ class StaticDataLoaderClass {
 
   registerData(state, staticData) {
     this.state = state;
-    this.LOADED_STATIC_DATA = staticData
+    this.DATA = staticData
 
-    this.ALL_PIPELINE_RUN_IDS = [...Object.entries(this.LOADED_STATIC_DATA)
+    this.ALL_PIPELINE_RUN_IDS = [...Object.entries(this.DATA)
       .filter(([runId, v]) => v.type === "pipeline")
       .map(([runId, v]) => runId)
     ];
@@ -208,9 +208,9 @@ class StaticDataLoaderClass {
       new Map(this.ALL_PIPELINE_RUN_IDS.map(pipelineId => {
         const result = [];
 
-        Object.entries(this.LOADED_STATIC_DATA).forEach(([vRunId, v]) => {
+        Object.entries(this.DATA).forEach(([vRunId, v]) => {
           if ((v.type === "task") && (v.parent_id === pipelineId)) {
-            Object.entries(this.LOADED_STATIC_DATA).forEach(([wRunId, w]) => {
+            Object.entries(this.DATA).forEach(([wRunId, w]) => {
               if ((w.type === "run") && (w.parent_id === vRunId)) {
                 result.push(wRunId);
               }
@@ -228,7 +228,7 @@ class StaticDataLoaderClass {
       result1.set(this.ALL_PIPELINE_RUNS_ID, "All pipeline runs");
 
       const result2 = new Map();
-      Object.entries(this.LOADED_STATIC_DATA)
+      Object.entries(this.DATA)
         .filter(([runId, entry]) => entry.type === "task")
         .forEach(([runId, entry]) => {
           const entryExperimentId = getTaskId(entry);
@@ -296,7 +296,7 @@ export class StaticMlflowService {
   }
 
   static getRunRawData(run_id) {
-    return StaticDataLoader.LOADED_STATIC_DATA[run_id];
+    return StaticDataLoader.DATA[run_id];
   }
 
   static getRun({
@@ -392,14 +392,14 @@ export class StaticMlflowService {
       const validSources = new Set(experiment_ids.map(eid => StaticDataLoader.LOOKUP_IDX_TO_TASK_SOURCE_NAME.get(eid)));
 
       // get parent Task id:s whose runs should be shown
-      const taskIds = new Set(Object.entries(StaticDataLoader.LOADED_STATIC_DATA)
+      const taskIds = new Set(Object.entries(StaticDataLoader.DATA)
         .filter(([runId, v]) => v.type === "task")
         .filter(([runId, v]) => validSources.has(v["metadata"]["attributes"]["task.notebook"]))
         .map(([runId, v]) => runId)
       );
 
       // find all children (run:s) under these tasks
-      result = [...Object.entries(StaticDataLoader.LOADED_STATIC_DATA)
+      result = [...Object.entries(StaticDataLoader.DATA)
         .filter(([runId, v]) => v.type === "run")
         .filter(([runId, v]) => taskIds.has(v["parent_id"]))
         .map(([runId, v]) => reformatEntry(runId, v, expId))

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -177,7 +177,6 @@ class StaticDataLoaderClass {
 
   constructor() {
     this.loaderPromise = getArtifactContent('./ui_static_data.json');
-    this.state = "LOADING";
 
     //
     // Note:
@@ -190,17 +189,17 @@ class StaticDataLoaderClass {
     // we initially just return "no data" (and we do not attempt to hide/disable
     // the main UI while data is loading).
     //
-    this.registerData({});
+    this.registerData("LOADING", {});
 
     this.loaderPromise.then((value) => {
-      this.registerData(JSON.parse(value));
-      this.state = "LOADED";
+      this.registerData("LOADED", JSON.parse(value));
     }).catch((err) => {
-      this.state = "FAILED";
+      this.registerData("FAILED", {});
     });
   }
 
-  registerData(staticData) {
+  registerData(state, staticData) {
+    this.state = state;
     this.LOADED_STATIC_DATA = staticData
 
     this.ALL_PIPELINE_RUN_IDS = [...Object.entries(this.LOADED_STATIC_DATA)

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -176,7 +176,7 @@ class StaticDataLoaderClass {
   state;
 
   constructor() {
-    this.loaderPromise = getArtifactContent('./data.json');
+    this.loaderPromise = getArtifactContent('./ui_static_data.json');
     this.state = "LOADING";
 
     //

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -203,9 +203,6 @@ class StaticDataLoaderClass {
   registerData(staticData) {
     this.LOADED_STATIC_DATA = staticData
 
-    // --- Process loaded data ---
-
-    // Array of ID:s for pipeline runs
     this.ALL_PIPELINE_RUN_IDS = [...Object.entries(this.LOADED_STATIC_DATA)
       .filter(([runId, v]) => v.type === "pipeline")
       .map(([runId, v]) => runId)
@@ -359,12 +356,12 @@ export class StaticMlflowService {
 
     var result;
 
-    if ((experiment_ids.length === 1) && one(experiment_ids) === StaticMlflowService.ALL_PIPELINE_RUNS_ID) {
+    if ((experiment_ids.length === 1) && one(experiment_ids) === StaticDataLoader.ALL_PIPELINE_RUNS_ID) {
       // Return all pipeline runs with individual task runs as children
 
       result = [];
       for (const pipelineId of StaticDataLoader.ALL_PIPELINE_RUN_IDS) {
-        const pipelineEntry = reformatEntry(pipelineId, STATIC_DATA[pipelineId], StaticMlflowService.ALL_PIPELINE_RUNS_ID)
+        const pipelineEntry = reformatEntry(pipelineId, STATIC_DATA[pipelineId], StaticDataLoader.ALL_PIPELINE_RUNS_ID)
 
         result.push(pipelineEntry);
 
@@ -380,7 +377,7 @@ export class StaticMlflowService {
           // A solution would be to preface runID:s with prefix depending on use,
           // like eg. "list-<run-id>" and "exp-<run-id>", but this also seems to
           // work.
-          result.push(reformatEntry(childId, STATIC_DATA[childId], StaticMlflowService.ALL_PIPELINE_RUNS_ID));
+          result.push(reformatEntry(childId, STATIC_DATA[childId], StaticDataLoader.ALL_PIPELINE_RUNS_ID));
         }
       }
     } else {

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -173,7 +173,7 @@ class StaticDataLoaderClass {
   state;
 
   constructor() {
-    this.loaderPromise = getArtifactContent('./ui_static_data.json');
+    this.loaderPromise = getArtifactContent('ui_static_data.json');
 
     //
     // Note:
@@ -270,7 +270,7 @@ class StaticDataLoaderClass {
         );
       }
 
-      return { experiments: experiments };
+      return { experiments };
     })();
   }
 }

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -316,7 +316,7 @@ export class StaticMlflowService {
     run_uuid,
     path
   }) {
-    const entry = StaticDataLoader.LOADED_STATIC_DATA[run_uuid];
+    const entry = StaticMlflowService.getRunRawData(run_uuid);
     var result;
 
     if (!!entry && !!entry.artifacts) {
@@ -359,7 +359,7 @@ export class StaticMlflowService {
       for (const pipelineId of StaticDataLoader.ALL_PIPELINE_RUN_IDS) {
         const pipelineEntry = reformatEntry(
           pipelineId,
-          StaticDataLoader.LOADED_STATIC_DATA[pipelineId],
+          StaticMlflowService.getRunRawData(pipelineId),
           StaticDataLoader.ALL_PIPELINE_RUNS_ID
         );
 
@@ -380,7 +380,7 @@ export class StaticMlflowService {
           result.push(
             reformatEntry(
               childId,
-              StaticDataLoader.LOADED_STATIC_DATA[childId],
+              StaticMlflowService.getRunRawData(childId),
               StaticDataLoader.ALL_PIPELINE_RUNS_ID
             )
           );

--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -1,7 +1,7 @@
 import {
   STATIC_DATA
 } from './StaticData';
-
+import { getArtifactContent } from '../../common/utils/ArtifactUtils'
 
 const one = (xs) => {
   if (xs.length === 1) {
@@ -233,6 +233,34 @@ const reformatEntry = (runId, entry, experimentId) => {
 
   return result;
 };
+
+class StaticDataLoaderClass {
+  // static data to show in UI
+  LOADED_STATIC_DATA = undefined;
+
+  // promise (for attaching callbacks)
+  loaderPromise
+
+  // "LOADING NOT STARTED" -> "LOADING" -> {"LOADED" or "FAILED"}
+  state = "LOADING NOT STARTED"
+
+  constructor() {
+    console.log("startLoadingData:");
+    this.loaderPromise = getArtifactContent('./data.json');
+    this.state = "LOADING";
+
+    const self = this;
+
+    this.loaderPromise.then((value) => {
+      console.log("startLoadingData: Loaded dynamic data...");
+      self.LOADED_STATIC_DATA = JSON.parse(value);
+      self.state = "LOADED";
+      console.log("startLoadingData: Done");
+    });
+  }
+}
+
+export const StaticDataLoader = new StaticDataLoaderClass();
 
 export class StaticMlflowService {
   static listExperiments(dummy_arg) {


### PR DESCRIPTION
This PR moves from using `STATIC_DATA` (loaded as below) to dynamically loading the JSON from a static asset JSON file over https.

```js
import { STATIC_DATA } from './StaticData';
```

This PR also implements basic loading screen "Data loading.... Please wait" during loading stage before main UI is shown. 

#### UI + pipeline testing
- https://github.com/matiasdahl/dev-mnist-digits-demo-pipeline/pull/7

----

The contributions to the MLFlow code base in this PR are copyright Matias Dahl 2022, and are released under the terms of the Apache 2 license.