### PR TITLE
CI/CD GHA: Refactor docker setup for building wheel

### DIFF
--- a/.github/workflows/build-and-publish-webui-py-package.yml
+++ b/.github/workflows/build-and-publish-webui-py-package.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: "webui-py-package: build Python wheel with UI static assets"
         run: |
-          make webui-py-package/build-wheel-file[in-docker]
+          make webui-py-package/build-wheel[in-docker]
 
       - name: "Store output wheel-file as Github build artefact"
         uses: actions/upload-artifact@v3

--- a/mlflow/server/js/makefile
+++ b/mlflow/server/js/makefile
@@ -139,7 +139,8 @@ webui-py-package/docker/build-image:
 webui-py-package/build-wheel[in-docker]:
 	# This command assumes that the ./build folder contains the compiled assets
 	# and these are included in the Python package.
-
-	cd webui-py-package
-	make set-assets ASSETS_DIRECTORY=$$(pwd)/../build/.
-	make build-wheel[in-docker]
+	(\
+	    export ASSETS_DIRECTORY=$$(pwd)/build/.; \
+	    cd webui-py-package; \
+	    make build-wheel[in-docker];
+	)

--- a/mlflow/server/js/makefile
+++ b/mlflow/server/js/makefile
@@ -135,12 +135,13 @@ docker-build-static-ui:
 
 webui-py-package/docker/build-image:
 	cd webui-py-package/docker
-	make build-image
 
-webui-py-package/build-wheel-file[in-docker]:
+	make run[in-docker] DOCKER_COMMAND="pwd"
+
+webui-py-package/build-wheel[in-docker]:
 	# This command assumes that the ./build folder contains the compiled assets
 	# and these are included in the Python package.
 
 	cd webui-py-package
 	make set-assets ASSETS_DIRECTORY=$$(pwd)/../build/.
-	make build-wheel-file[in-docker]
+	make build-wheel[in-docker]

--- a/mlflow/server/js/makefile
+++ b/mlflow/server/js/makefile
@@ -134,9 +134,7 @@ docker-build-static-ui:
 # Tasks to build Python package with compiled static website assets.
 
 webui-py-package/docker/build-image:
-	cd webui-py-package/docker
-
-	make run[in-docker] DOCKER_COMMAND="pwd"
+	(cd webui-py-package/docker; make build-image)
 
 webui-py-package/build-wheel[in-docker]:
 	# This command assumes that the ./build folder contains the compiled assets

--- a/mlflow/server/js/webui-py-package/docker/.gitignore
+++ b/mlflow/server/js/webui-py-package/docker/.gitignore
@@ -1,0 +1,1 @@
+ui-asset-wheel-builder-docker-image

--- a/mlflow/server/js/webui-py-package/docker/makefile
+++ b/mlflow/server/js/webui-py-package/docker/makefile
@@ -1,24 +1,18 @@
-.PHONY: *
-
 SHELL := /bin/bash
 DOCKER_IMAGE_NAME := img-build-webui-py-package
 
-build-image:
-	@# Eg. DOCKER_ARGS="--no-cache" to force rebuild
-
+_docker_image: Dockerfile
 	docker \
 	    build \
-	    $(DOCKER_ARGS) \
 	    --file Dockerfile \
 	    --build-arg HOST_UID=$$(id -u) \
 	    --build-arg HOST_GID="$$(id -g)" \
 	    --tag $(DOCKER_IMAGE_NAME) \
 	    .
 
-run-command[in-docker]:
-	@# Note: In the below, quotes are needed if DOCKER_COMMAND contains spaces.
-	@# There might be better ways also?
+	touch $@
 
+run[in-docker]: _docker_image
 	docker run --rm \
 	    --tty $(DOCKER_ARGS) \
 	    $(DOCKER_IMAGE_NAME) \

--- a/mlflow/server/js/webui-py-package/docker/makefile
+++ b/mlflow/server/js/webui-py-package/docker/makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
-DOCKER_IMAGE_NAME := img-build-webui-py-package
+DOCKER_IMAGE_NAME := ui-asset-wheel-builder-docker-image
 
-_docker_image: Dockerfile
+$(DOCKER_IMAGE_NAME): Dockerfile
 	docker \
 	    build \
 	    --file Dockerfile \
@@ -12,7 +12,9 @@ _docker_image: Dockerfile
 
 	touch $@
 
-run[in-docker]: _docker_image
+build-image: $(DOCKER_IMAGE_NAME)
+
+run[in-docker]: $(DOCKER_IMAGE_NAME)
 	docker run --rm \
 	    --tty $(DOCKER_ARGS) \
 	    $(DOCKER_IMAGE_NAME) \

--- a/mlflow/server/js/webui-py-package/makefile
+++ b/mlflow/server/js/webui-py-package/makefile
@@ -15,28 +15,17 @@ build-wheel-file:
 	@find ./dist/ -type f
 	@echo "--------------------------------------------------------------------"
 
-set-assets:
-	@echo "--- Setting assets to content in directory $(ASSETS_DIRECTORY) ..."
-	@echo "--- Content:"
-	@find $(ASSETS_DIRECTORY)
-
-	@echo "--- Ensuring assets directory is empty"
-	rm -rf ./assets
-	mkdir assets
-
-	@echo "--- Copying assets ..."
-	cp -r $(ASSETS_DIRECTORY) ./assets/
-
 build-wheel[in-docker]:
 	(\
 	    cd docker; \
 	    make run[in-docker] \
 	        DOCKER_ARGS=" \
 	            --volume $$(pwd)/../:/webui-py-package \
+	            --volume ${ASSETS_DIRECTORY}:/assets \
 	            --workdir /webui-py-package \
 	        " \
 	        DOCKER_COMMAND="( \
-	            ASSETS_PATH='./assets' \
+	            ASSETS_PATH='/assets' \
 	            make build-wheel-file \
-			)"; \
+	        )"; \
 	)

--- a/mlflow/server/js/webui-py-package/makefile
+++ b/mlflow/server/js/webui-py-package/makefile
@@ -1,5 +1,4 @@
 .PHONY: *
-.ONESHELL:
 SHELL := /bin/bash
 
 # Note: Tasks should be started with cwd = directory of this makefile
@@ -8,13 +7,13 @@ clean:
 	rm -rf build dist pynb_dag_runner_webui.egg-info
 
 build-wheel-file:
-	make clean
+	@make clean
 
-	python3 setup.py bdist_wheel
+	@python3 setup.py bdist_wheel
 
-	echo "=== Output files in ./dist directory: ==="
-	find ./dist/
-	echo "========================================="
+	@echo "----------------- Output files in ./dist directory -----------------"
+	@find ./dist/ -type f
+	@echo "--------------------------------------------------------------------"
 
 set-assets:
 	@echo "--- Setting assets to content in directory $(ASSETS_DIRECTORY) ..."
@@ -28,11 +27,13 @@ set-assets:
 	@echo "--- Copying assets ..."
 	cp -r $(ASSETS_DIRECTORY) ./assets/
 
-build-wheel-file[in-docker]:
-	cd docker
-	make run-command[in-docker] \
-	    DOCKER_ARGS=" \
-	        --volume $$(pwd)/../:/webui-py-package \
-	        --workdir /webui-py-package \
-	    " \
-	    DOCKER_COMMAND="make build-wheel-file"; \
+build-wheel[in-docker]:
+	(\
+	    cd docker; \
+	    make run[in-docker] \
+	        DOCKER_ARGS=" \
+	            --volume $$(pwd)/../:/webui-py-package \
+	            --workdir /webui-py-package \
+	        " \
+	        DOCKER_COMMAND="make build-wheel-file"; \
+	)

--- a/mlflow/server/js/webui-py-package/makefile
+++ b/mlflow/server/js/webui-py-package/makefile
@@ -1,7 +1,7 @@
 .PHONY: *
 SHELL := /bin/bash
 
-# Note: Tasks should be started with cwd = directory of this makefile
+# Note: Tasks should be started is same directory as makefile
 
 clean:
 	rm -rf build dist pynb_dag_runner_webui.egg-info
@@ -35,5 +35,8 @@ build-wheel[in-docker]:
 	            --volume $$(pwd)/../:/webui-py-package \
 	            --workdir /webui-py-package \
 	        " \
-	        DOCKER_COMMAND="make build-wheel-file"; \
+	        DOCKER_COMMAND="( \
+	            ASSETS_PATH='./assets' \
+	            make build-wheel-file \
+			)"; \
 	)


### PR DESCRIPTION
Refactor docker build for wheel file with static assets

- use makefile dependencies for docker tasks
- remove use of temp dir for assets
- `setup.py` slight refactor
- revise task names

---

The contributions to the mlflow codebase in this PR are copyright Matias Dahl 2022, and are released under the terms of the Apache 2 license.