### PR TITLE
Release 0.0.2

### DIFF
--- a/mlflow/server/js/webui-py-package/PYTHON_PACKAGE_VERSION
+++ b/mlflow/server/js/webui-py-package/PYTHON_PACKAGE_VERSION
@@ -1,4 +1,4 @@
-0.0.1
+0.0.2
 
 # When a PR is merged to default branch, changes to this file will trigger:
 #


### PR DESCRIPTION
---
The contributions to the mlflow codebase in this PR are copyright Matias Dahl 2022, and are released under the terms of the Apache 2 license.