### PR TITLE
CI/CD GHA: fix path to PYTHON_PACKAGE_VERSION

### DIFF
--- a/.github/workflows/cicd_main-release.yml
+++ b/.github/workflows/cicd_main-release.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - static_mlflow
     paths:
-      - workspace/pynb_dag_runner/PYTHON_PACKAGE_VERSION
+      - mlflow/server/js/webui-py-package/PYTHON_PACKAGE_VERSION
 
 jobs:
   ci-run-tests:


### PR DESCRIPTION
---
The contributions to the mlflow codebase in this PR are copyright Matias Dahl 2022, and are released under the terms of the Apache 2 license.