### PR TITLE
Fix tag-pipeline; release 0.0.5; review comments on tagging

### DIFF
--- a/.github/workflows/cicd_main-release.yml
+++ b/.github/workflows/cicd_main-release.yml
@@ -25,6 +25,7 @@ jobs:
 
   cd-tag-release-commit:
     needs: cd-publish-package
+    runs-on: ubuntu-20.04
     permissions:
       contents: write
 
@@ -46,12 +47,5 @@ jobs:
       - name: Tag git-commit with version for this release
         shell: bash
         run: |
-          # Note:
-          #  - The original ML Flow project uses tags like 'v1.2.3' for
-          #    releases.
-          #  - These tags have not been removed form the static UI fork.
-          #  - To distinguish static-ui releases we use tags with format
-          #    'static-v1.2.3'
-          #
           git tag "static-v${PYTHON_PACKAGE_VERSION}" main
           git push origin "static-v${PYTHON_PACKAGE_VERSION}"

--- a/mlflow/server/js/webui-py-package/PYTHON_PACKAGE_VERSION
+++ b/mlflow/server/js/webui-py-package/PYTHON_PACKAGE_VERSION
@@ -1,4 +1,4 @@
-0.0.4
+0.0.5
 
 # When a PR is merged to default branch, changes to this file will trigger:
 #
@@ -6,4 +6,11 @@
 #      and then,
 #
 #  (2) tag the PR commit with the version.
+#
+#      Note on tags:
+#      - The original ML Flow project uses tags like 'v1.2.3' to
+#        mark releases.
+#      - These tags have not been removed form the static UI repo fork.
+#      - To distinguish static-ui releases we use tags with format
+#        'static-v1.2.3' to mark commits that have been released.
 #


### PR DESCRIPTION

---
The contributions to the mlflow codebase in this PR are copyright Matias Dahl 2022, and are released under the terms of the Apache 2 license.