### PR TITLE
Render Gantt and DAG diagram using Mermaid Javascript renderer

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -29,6 +29,7 @@
     "json-bigint": "databricks/json-bigint#a1defaf9cd8dd749f0fd4d5f83a22cd846789658",
     "leaflet": "^1.5.1",
     "lodash": "^4.17.21",
+    "mermaid": "8.10.2",
     "moment": "^2.24.0",
     "plotly.js": "1.50.0",
     "prop-types": "^15.7.2",

--- a/mlflow/server/js/src/common/utils/FileUtils.js
+++ b/mlflow/server/js/src/common/utils/FileUtils.js
@@ -40,6 +40,7 @@ export const TEXT_EXTENSIONS = new Set([
   MLPROJECT_FILE_NAME.toLowerCase(),
   MLMODEL_FILE_NAME.toLowerCase(),
   'jsonnet',
+  'mmd', // mermaid input file
 ]);
 export const HTML_EXTENSIONS = new Set(['html']);
 export const MAP_EXTENSIONS = new Set(['geojson']);

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.js
@@ -19,7 +19,8 @@ import { CollapsibleSection } from '../../common/components/CollapsibleSection';
 import { EditableNote } from '../../common/components/EditableNote';
 import { setTagApi, deleteTagApi } from '../actions';
 import { PageHeader, OverflowMenu } from '../../shared/building_blocks/PageHeader';
-import { DataBacklinkFooter } from '../static-data/UIConstants.js'
+import { DataBacklinkFooter } from '../static-data/UIConstants.js';
+import RemotelyFetchedMermaidView from '../../experiment-tracking/components/artifact-view-components/RemotelyFetchedMermaidView';
 
 export class RunViewImpl extends Component {
   static propTypes = {
@@ -384,43 +385,89 @@ export class RunViewImpl extends Component {
               <textarea className='run-command text-area' readOnly value={runCommand} />
             </CollapsibleSection>
           ) : null}
-          <CollapsibleSection
-            title={
-              <span>
-                <FormattedMessage
-                  defaultMessage='Description'
-                  description='Label for the notes editable content for the experiment run'
-                />
-                {!process.env.HOST_STATIC_SITE && !showNoteEditor && (
-                  <>
-                    {' '}
-                    <Button
-                      type='link'
-                      onClick={this.startEditingDescription}
-                      data-test-id='edit-description-button'
-                    >
-                      <FormattedMessage
-                        defaultMessage='Edit'
-                        // eslint-disable-next-line max-len
-                        description='Text for the edit button next to the description section title on the run view'
-                      />
-                    </Button>
-                  </>
-                )}
-              </span>
-            }
-            forceOpen={showNoteEditor}
-            defaultCollapsed={!noteContent}
-            onChange={this.handleCollapseChange('notes')}
-            data-test-id='run-notes-section'
-          >
-            <EditableNote
-              defaultMarkdown={noteContent}
-              onSubmit={this.handleSubmitEditNote}
-              onCancel={this.handleCancelEditNote}
-              showEditor={showNoteEditor}
-            />
-          </CollapsibleSection>
+
+          {process.env.HOST_STATIC_SITE ? null :
+            <CollapsibleSection
+              title={
+                <span>
+                  <FormattedMessage
+                    defaultMessage='Description'
+                    description='Label for the notes editable content for the experiment run'
+                  />
+                  {!process.env.HOST_STATIC_SITE && !showNoteEditor && (
+                    <>
+                      {' '}
+                      <Button
+                        type='link'
+                        onClick={this.startEditingDescription}
+                        data-test-id='edit-description-button'
+                      >
+                        <FormattedMessage
+                          defaultMessage='Edit'
+                          // eslint-disable-next-line max-len
+                          description='Text for the edit button next to the description section title on the run view'
+                        />
+                      </Button>
+                    </>
+                  )}
+                </span>
+              }
+              forceOpen={showNoteEditor}
+              defaultCollapsed={!noteContent}
+              onChange={this.handleCollapseChange('notes')}
+              data-test-id='run-notes-section'
+            >
+              <EditableNote
+                defaultMarkdown={noteContent}
+                onSubmit={this.handleSubmitEditNote}
+                onCancel={this.handleCancelEditNote}
+                showEditor={showNoteEditor}
+              />
+            </CollapsibleSection>
+          }
+
+          {process.env.HOST_STATIC_SITE ?
+            <CollapsibleSection
+              title={
+                <span>
+                  <FormattedMessage
+                    defaultMessage='Task dependency graph'
+                    description='Mermaid rendered graph of task dependencies for pipeline'
+                  />
+                </span>
+              }
+              defaultCollapsed={false}
+              onChange={this.handleCollapseChange('task-dependency-dag')}
+              data-test-id='run-task-dependency-dag-section'
+            >
+              <RemotelyFetchedMermaidView
+                artifactRootUri={run.getArtifactUri()}
+                path="dag.mmd"
+              />
+            </CollapsibleSection>
+          : null}
+
+          {process.env.HOST_STATIC_SITE ?
+            <CollapsibleSection
+              title={
+                <span>
+                  <FormattedMessage
+                    defaultMessage='Gantt diagram'
+                    description='Mermaid rendered Gantt diagram for task runtimes'
+                  />
+                </span>
+              }
+              defaultCollapsed={false}
+              onChange={this.handleCollapseChange('task-gantt-runtimes-diagram')}
+              data-test-id='run-task-gantt-section'
+            >
+              <RemotelyFetchedMermaidView
+                artifactRootUri={run.getArtifactUri()}
+                path="gantt.mmd"
+              />
+            </CollapsibleSection>
+          : null}
+
           <CollapsibleSection
             defaultCollapsed
             title={this.renderSectionTitle(

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/RemotelyFetchedMermaidView.css
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/RemotelyFetchedMermaidView.css
@@ -1,0 +1,10 @@
+/*
+ * Overflow mermaid diagrams that do not fit on screen
+ * (with horizontal scroll bar).
+ *
+ * See https://github.com/mermaid-js/mermaid/issues/652
+ */
+.mermaid-container {
+  width: 100%;
+  overflow-x: scroll;
+}

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/RemotelyFetchedMermaidView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/RemotelyFetchedMermaidView.js
@@ -1,0 +1,87 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { getSrc } from './ShowArtifactPage';
+import { getArtifactContent } from '../../../common/utils/ArtifactUtils';
+import './RemotelyFetchedMermaidView.css';
+import './ShowArtifactTextView.css';
+import mermaid from 'mermaid';
+
+// ---- based on ShowArtifactTextView ----
+
+class RemotelyFetchedMermaidView extends Component {
+  constructor(props) {
+    super(props);
+    this.fetchArtifacts = this.fetchArtifacts.bind(this);
+  }
+
+  static propTypes = {
+    // runUuid: PropTypes.string.isRequired,
+    path: PropTypes.string.isRequired,
+    artifactRootUri: PropTypes.string.isRequired,
+    getArtifact: PropTypes.func,
+  };
+
+  static defaultProps = {
+    getArtifact: getArtifactContent,
+  };
+
+  state = {
+    loading: true,
+    error: undefined,
+    text: undefined,
+  };
+
+  componentDidMount() {
+    // See
+    // https://github.com/mermaidjs/mermaidjs.github.io/blob/master/mermaidAPI.md
+    mermaid.initialize({
+      startOnLoad: true,
+      securityLevel: 'loose',
+      flowchart: {
+        useMaxWidth: false,
+        htmlLabels: true
+      }
+    });
+    this.fetchArtifacts();
+  }
+
+  componentDidUpdate(prevProps) {
+    mermaid.contentLoaded()
+  }
+
+  render() {
+    if (this.state.loading) {
+      return <span>Loading...</span>;
+    }
+    if (this.state.error) {
+      return (
+        <span>
+          Oops we couldn't load your file because of an error.
+        </span>
+      );
+    } else {
+      return (
+        <div className='mermaid mermaid-container'>
+          {this.state.text}
+        </div>
+      );
+    }
+  }
+
+  /** Fetches artifacts and updates component state with the result */
+  fetchArtifacts() {
+    const artifactLocation = getSrc(
+      this.props.path, undefined, this.props.artifactRootUri
+    );
+    this.props
+      .getArtifact(artifactLocation)
+      .then((text) => {
+        this.setState({ text: text, loading: false });
+      })
+      .catch((error) => {
+        this.setState({ error: error, loading: false });
+      });
+  }
+}
+
+export default RemotelyFetchedMermaidView;

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/RemotelyFetchedMermaidView.js
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/RemotelyFetchedMermaidView.js
@@ -15,7 +15,6 @@ class RemotelyFetchedMermaidView extends Component {
   }
 
   static propTypes = {
-    // runUuid: PropTypes.string.isRequired,
     path: PropTypes.string.isRequired,
     artifactRootUri: PropTypes.string.isRequired,
     getArtifact: PropTypes.func,

--- a/mlflow/server/js/webui-py-package/PYTHON_PACKAGE_VERSION
+++ b/mlflow/server/js/webui-py-package/PYTHON_PACKAGE_VERSION
@@ -1,4 +1,4 @@
-0.0.8
+0.0.9
 
 # When a PR is merged to default branch, changes to this file will trigger:
 #


### PR DESCRIPTION
Removes need for converting diagrams into PNG -> simpler deploy pipeline :-)

---

The contributions to the mlflow codebase in this PR are copyright Matias Dahl 2022, and are released under the terms of the Apache 2 license.