### PR TITLE
Fix path to artifacts; release 0.0.12

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
+++ b/mlflow/server/js/src/experiment-tracking/static-data/StaticMlflowService.js
@@ -28,7 +28,7 @@ const reformatEntry = (runId, entry, experimentId) => {
       start_time: new Date(entry.timing_start_iso8601).getTime(),
       end_time: new Date(entry.timing_end_iso8601).getTime(),
       // asset directory structure could be included in JSON to keep control in one place
-      artifact_uri: `/artifacts/${entry.type}/${runId}`,
+      artifact_uri: `artifacts/${entry.type}/${runId}`,
       lifecycle_stage: "active",
       run_id: runId
     },

--- a/mlflow/server/js/webui-py-package/PYTHON_PACKAGE_VERSION
+++ b/mlflow/server/js/webui-py-package/PYTHON_PACKAGE_VERSION
@@ -1,4 +1,4 @@
-0.0.11
+0.0.12
 
 # When a PR is merged to default branch, changes to this file will trigger:
 #


### PR DESCRIPTION
`/artifacts/` will not work when deployed to Github Pages where URL is like

https://pynb-dag-runner.github.io/mnist-digits-demo-pipeline/#/experiments/eda

A leading slash will remove the repo name `mnist-digits-demo-pipeline` in this path. 